### PR TITLE
Redis Cloud Integration is now 30MB free

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "SlackHQ"
   ],
   "addons": [
-    "rediscloud:25"
+    "rediscloud:30"
   ],
   "env": {
     "HUBOT_SLACK_TOKEN": {


### PR DESCRIPTION
Integration isn't currently working because of this one line. Should fix it, but I'm not positive.